### PR TITLE
add title overlay to video placeholder

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -23,6 +23,16 @@ $_n-video_applied: false !default;
 		}
 	}
 
+	.n-video__title {
+		position: absolute;
+		top: 0;
+		left: 0;
+		padding: 8px;
+		background-color: rgba(getColor('grey-tint4'), 0.9);
+		color: white;
+		z-index: 2;
+	}
+
 	.n-video__play-button {
 		position: absolute;
 		width: 100%;

--- a/src/models/brightcove.js
+++ b/src/models/brightcove.js
@@ -105,6 +105,11 @@ class Brightcove extends Video {
 		this.containerEl.classList.add('n-video--placeholder');
 		this.containerEl.appendChild(this.placeholderEl);
 
+		const titleEl = document.createElement('div');
+		titleEl.className = 'n-video__title';
+		titleEl.textContent = this.brightcoveData.name;
+		this.containerEl.appendChild(titleEl);
+
 		if (this.opts.playButton) {
 
 			const playButtonEl = document.createElement('button');
@@ -116,6 +121,7 @@ class Brightcove extends Video {
 
 			playButtonEl.addEventListener('click', () => {
 				this.containerEl.removeChild(playButtonEl);
+				this.containerEl.removeChild(titleEl);
 				this.removePlaceholder();
 				this.addVideo();
 				this.el.play();

--- a/test/models/brightcove.spec.js
+++ b/test/models/brightcove.spec.js
@@ -95,6 +95,7 @@ describe('Brightcove', () => {
 					'?source=next'
 				);
 				containerEl.querySelector('.n-video__play-button').should.exist;
+				containerEl.querySelector('.n-video__title').textContent.should.equal('A hated rally');
 			});
 	});
 


### PR DESCRIPTION
For Brightcove videos, add the title as an overlay on the placeholder.

<img width="826" alt="screen shot 2016-01-28 at 12 11 25" src="https://cloud.githubusercontent.com/assets/8938227/12644119/847f870a-c5b8-11e5-9129-68f699b29d54.png">
