### PR TITLE
make placeholder title optional

### DIFF
--- a/src/models/brightcove.js
+++ b/src/models/brightcove.js
@@ -105,10 +105,13 @@ class Brightcove extends Video {
 		this.containerEl.classList.add('n-video--placeholder');
 		this.containerEl.appendChild(this.placeholderEl);
 
-		const titleEl = document.createElement('div');
-		titleEl.className = 'n-video__title';
-		titleEl.textContent = this.brightcoveData.name;
-		this.containerEl.appendChild(titleEl);
+		let titleEl;
+		if (this.opts.placeholderTitle) {
+			titleEl = document.createElement('div');
+			titleEl.className = 'n-video__title';
+			titleEl.textContent = this.brightcoveData.name;
+			this.containerEl.appendChild(titleEl);
+		}
 
 		if (this.opts.playButton) {
 
@@ -121,7 +124,9 @@ class Brightcove extends Video {
 
 			playButtonEl.addEventListener('click', () => {
 				this.containerEl.removeChild(playButtonEl);
-				this.containerEl.removeChild(titleEl);
+				if (titleEl) {
+					this.containerEl.removeChild(titleEl);
+				}
 				this.removePlaceholder();
 				this.addVideo();
 				this.el.play();

--- a/src/models/video.js
+++ b/src/models/video.js
@@ -7,6 +7,7 @@ class Video {
 			classes: [],
 			optimumWidth: null,
 			placeholder: false,
+			placeholderTitle: false,
 			playButton: true,
 			data: null
 		};

--- a/test/models/brightcove.spec.js
+++ b/test/models/brightcove.spec.js
@@ -95,6 +95,21 @@ describe('Brightcove', () => {
 					'?source=next'
 				);
 				containerEl.querySelector('.n-video__play-button').should.exist;
+			});
+	});
+
+	it('should be able to create a placeholder with a title', () => {
+		const brightcove = new Brightcove(containerEl, { placeholder: true, placeholderTitle: true });
+		return brightcove
+			.init()
+			.then(() => {
+				const placholderEl = containerEl.querySelector('img');
+				placholderEl.getAttribute('src').should.equal(
+					'https://next-geebee.ft.com/image/v1/images/raw/' +
+					'https%3A%2F%2Fbcsecure01-a.akamaihd.net%2F13%2F47628783001%2F201502%2F2470%2F47628783001_4085962850001_MAS-VIDEO-AuthersNote-stock-market.jpg%3FpubId%3D47628783001' +
+					'?source=next'
+				);
+				containerEl.querySelector('.n-video__play-button').should.exist;
 				containerEl.querySelector('.n-video__title').textContent.should.equal('A hated rally');
 			});
 	});


### PR DESCRIPTION
@adgad Suggest that this is good practice anyway to make the title optional, even if homepage wants to do it this way. A further consideration is how it responds to size. For article, where the video would be full width at small sizes I was thinking of reducing the font size. 

But this wouldn't work for homepage where you've got 2 or 4 in a row.