### PR TITLE
Amend: n-video__title z-index value

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -30,7 +30,7 @@ $_n-video_applied: false !default;
 		padding: 8px;
 		background-color: rgba(getColor('grey-tint4'), 0.9);
 		color: white;
-		z-index: 2;
+		z-index: 1;
 	}
 
 	.n-video__play-button {

--- a/main.scss
+++ b/main.scss
@@ -30,7 +30,6 @@ $_n-video_applied: false !default;
 		padding: 8px;
 		background-color: rgba(getColor('grey-tint4'), 0.9);
 		color: white;
-		z-index: 1;
 	}
 
 	.n-video__play-button {
@@ -44,7 +43,6 @@ $_n-video_applied: false !default;
 		text-indent: -9999px;
 		cursor: pointer;
 		border: 0;
-		z-index: 1;
 
 		&:after {
 			@include nextIcon(play, #fcfcfc, 40);


### PR DESCRIPTION
cc @andygnewman 

To fix:

![screen shot 2016-05-05 at 14 22 39](https://cloud.githubusercontent.com/assets/10484515/15045021/21a3b088-12d0-11e6-94a0-fade6e21c3a8.png)

Given the `n-video__title` and `n-video__play-button` elements are absolutely positioned, as long as they follow the `img` in the html, they seem to be able to do without requiring a z-index.

I've checked by dropped the subnav across it as well as a myFT overlay, and all sits underneath both as desired.

Are there any potential instances you can think of whereby absence of z-index on these elements would be problematic?